### PR TITLE
added static ipc support and configurabe dynamic ipc support

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ For Windows, config file is located in where the `mpv.exe` executable is.
 
 * **active** (default: yes): whether to activate at launch (yes/no)
 * **binary_path**: full path to the mpv-discord's binary file
+* **static_ipc**: (default: yes) weather to create a  static icp socket or a dynamic one. Static sockets will be at `/tmp/mpvsocket` on macos/Linux and `.\mpvpipe` on Windows. Dynamic sockets will be created in a subfolder of the current temporary folder. The subfolder is set by **dynamic_ipc_prefix**, and will contain one pipe file for each mpv instance, with the name of the pipe being the PID of the respective mpv process.
+* **dynamic_ipc_prefix** (default: `mpvSockets`): the path to be used for creating dynamic ipc sockets
 
 ## How It Works
 

--- a/mpv-discord/main.go
+++ b/mpv-discord/main.go
@@ -15,12 +15,15 @@ import (
 
 var client *mpvrpc.Client
 var presence *discordrpc.Presence
+var pipe_path string
 
 func init() {
 	log.SetFlags(log.Lmsgprefix)
 	log.SetPrefix("[discord] ")
 
-	client = mpvrpc.NewClient(os.Args[1])
+	client = mpvrpc.NewClient(os.Args[0])
+	pipe_path = os.Args[1]
+
 	presence = discordrpc.NewPresence("737663962677510245")
 }
 
@@ -112,7 +115,7 @@ func getActivity() (activity discordrpc.Activity, err error) {
 }
 
 func openClient() {
-	if err := client.Open(); err != nil {
+	if err := client.Open(pipe_path); err != nil {
 		log.Fatalln(err)
 	}
 	log.Println("(mpv-ipc): connected")

--- a/mpv-discord/mpvrpc/client.go
+++ b/mpv-discord/mpvrpc/client.go
@@ -31,8 +31,8 @@ func NewClient(pid string) *Client {
 	return client
 }
 
-func (c *Client) Open() (err error) {
-	c.socket, err = pipe.GetPipeSocket(c.pid)
+func (c *Client) Open(pipe_path string) (err error) {
+	c.socket, err = pipe.GetPipeSocket(pipe_path)
 	go c.readloop()
 	return
 }

--- a/mpv-discord/mpvrpc/pipe/pipe_unix.go
+++ b/mpv-discord/mpvrpc/pipe/pipe_unix.go
@@ -8,6 +8,8 @@ import (
 	"time"
 )
 
-func GetPipeSocket(pid string) (net.Conn, error) {
-	return net.DialTimeout("unix", fmt.Sprintf("/tmp/mpv-discord-%s", pid), time.Second*5)
+func GetPipeSocket(pipe_path string) (net.Conn, error) {
+
+	return net.DialTimeout("unix", fmt.Sprintf(pipe_path), time.Second*5)
+
 }

--- a/mpv-discord/mpvrpc/pipe/pipe_windows.go
+++ b/mpv-discord/mpvrpc/pipe/pipe_windows.go
@@ -10,6 +10,7 @@ import (
 	npipe "gopkg.in/natefinch/npipe.v2"
 )
 
-func GetPipeSocket(pid string) (net.Conn, error) {
-	return npipe.DialTimeout(fmt.Sprintf(`\\.\pipe\tmp\mpv-discord-%s`, pid), time.Second*5)
+func GetPipeSocket(pipe_path string) (net.Conn, error) {
+	return npipe.DialTimeout(fmt.Sprintf(pipe_path), time.Second*5)
+
 }

--- a/script-opts/discord.conf
+++ b/script-opts/discord.conf
@@ -1,2 +1,4 @@
 active=yes
 binary_path=
+static_ipc=yes
+dynamic_ipc_prefix=mpvSockets

--- a/scripts/discord.lua
+++ b/scripts/discord.lua
@@ -4,9 +4,36 @@ utils = require("mp.utils")
 
 options = {
     active = true,
-    binary_path = ""
+    binary_path = "",
+    static_ipc = true,
+    dynamic_ipc_prefix = ""
 }
 opts.read_options(options, "discord")
+
+local function get_temp_path()
+    local directory_seperator = package.config:match("([^\n]*)\n?")
+    local example_temp_file_path = os.tmpname()
+
+    -- remove generated temp file
+    pcall(os.remove, example_temp_file_path)
+
+    local seperator_idx = example_temp_file_path:reverse():find(directory_seperator)
+    local temp_path_length = #example_temp_file_path - seperator_idx
+
+    return example_temp_file_path:sub(1, temp_path_length)
+end
+
+function join_paths(...)
+    local arg={...}
+    path = ""
+    for i,v in ipairs(arg) do
+        path = utils.join_path(path, tostring(v))
+    end
+    return path;
+end
+
+tempDir = get_temp_path()
+os.execute("mkdir " .. join_paths(tempDir, options.dynamic_ipc_prefix) .. " 2>/dev/null")
 
 if options.binary_path == "" then
     msg.fatal("Missing binary path in config file.")
@@ -17,8 +44,33 @@ version = "1.2.1"
 msg.info(("mpv-discord v%s by tnychn"):format(version))
 
 pid = utils.getpid()
-socket_path = ("/tmp/mpv-discord-%s"):format(pid)
+sep = package.config:sub(1,1)
+socket_path = ""
+static_ipc_str = 'false'
+
+if sep == '/' then
+    if options.static_ipc then
+        static_ipc_str = "true"
+        socket_path = ("/tmp/mpvsocket")
+    else
+        socket_path = join_paths(tempDir, options.dynamic_ipc_prefix, pid)
+    end
+    
+else
+    if options.static_ipc then
+        static_ipc_str = "true"
+        socket_path = ("mpvpipe")
+    else
+        socket_path = join_paths(tempDir, options.dynamic_ipc_prefix, pid)
+    end
+    
+end
 mp.set_property("input-ipc-server", socket_path)
+
+
+if options.static_ipc then
+    static_ipc_str = "true"
+end
 
 launched = false
 mp.register_event("file-loaded", function()
@@ -26,7 +78,7 @@ mp.register_event("file-loaded", function()
 --         utils.subprocess_detached({
 --             args = { options.binary_path, pid }
 --         })
-        io.popen(options.binary_path .. " " .. pid)
+        io.popen(options.binary_path .. " " .. socket_path)
         launched = true
         msg.info(("(mpv-ipc): %s"):format(socket_path))
     end


### PR DESCRIPTION
Added support for configuring weather a dynamic or static ipc socket should be used, with the abilitu to configure where
the dynamic ipc socket should be created. It would potentially also make sense to enable configuring the path of the static 
ipc socket, though that seems less usefull to me since that is typically set to /tmp/mpvsocket.

I tested this on linux, in combination with SVP, and as long as both are configured the same way 
(either both use /tmp/mpvsocket or both use /tmp/mpvSockets/$PID), they work flawlessly with each other.

I did not test on macos or windows, as I currently dont have these OS available to me. 

macos should work out of the box, though windows might be tricky.